### PR TITLE
FIX: Enables EventBridge to directly invoke Lambda worker

### DIFF
--- a/terraform/worker.tf
+++ b/terraform/worker.tf
@@ -32,6 +32,15 @@ module "lambda_function" {
     S3_BUCKET_NAME = var.s3_bucket_name
     ARGO_DAC       = var.argo_dac
   }
+
+  # Allow EventBridge to invoke this Lambda
+  create_current_version_allowed_triggers = false
+  allowed_triggers = {
+    EventBridgeRule = {
+      principal  = "events.amazonaws.com"
+      source_arn = module.eventbridge.eventbridge_rule_arns["weekly_sync"]
+    }
+  }
 }
 
 module "docker_image" {
@@ -74,8 +83,8 @@ module "eventbridge" {
   }
 
   # IAM permissions for EventBridge to invoke Lambda
-  attach_lambda_policy = true
-  lambda_target_arns   = [module.lambda_function.lambda_function_arn]
+  # attach_lambda_policy = true
+  # lambda_target_arns   = [module.lambda_function.lambda_function_arn]
 
   tags = {
     Name = "atlas-worker-scheduler"


### PR DESCRIPTION
Adds explicit trigger permissions for EventBridge to invoke the Lambda worker, replacing previous IAM policy attachment which was not trgerring the lamda due to permission errors



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated infrastructure configuration for background task triggering, improving system reliability and event handling mechanisms.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->